### PR TITLE
fix: lastDate in Invoice as Date

### DIFF
--- a/iec_api/models/invoice.py
+++ b/iec_api/models/invoice.py
@@ -7,6 +7,7 @@ from mashumaro.codecs import BasicDecoder
 
 from iec_api.commons import convert_to_tz_aware_datetime
 from iec_api.models.meter_reading import MeterReading
+from iec_api.models.models_commons import FormattedDate
 from iec_api.models.response_descriptor import ResponseWithDescriptor
 
 # GET https://iecapi.iec.co.il//api/billingCollection/invoices/{bp_number}/{contract_number}
@@ -67,7 +68,9 @@ class Invoice(DataClassDictMixin):
     invoice_id: int = field(metadata=field_options(alias="invoiceId"))
     contract_number: int = field(metadata=field_options(alias="contractNumber"))
     order_number: int = field(metadata=field_options(alias="orderNumber"))
-    last_date: Optional[str] = field(metadata=field_options(alias="lastDate"))
+    last_date: Optional[str] = field(
+        metadata=field_options(alias="lastDate", serialization_strategy=FormattedDate("%d/%M/%Y"))
+    )
     invoice_payment_status: int = field(metadata=field_options(alias="invoicePaymentStatus"))
     document_id: str = field(metadata=field_options(alias="documentID"))
     days_period: str = field(metadata=field_options(alias="daysPeriod"))

--- a/iec_api/models/models_commons.py
+++ b/iec_api/models/models_commons.py
@@ -1,0 +1,25 @@
+from datetime import date, datetime
+
+from mashumaro.types import SerializationStrategy
+
+
+class FormattedDateTime(SerializationStrategy):
+    def __init__(self, fmt):
+        self.fmt = fmt
+
+    def serialize(self, value: datetime) -> str:
+        return value.strftime(self.fmt)
+
+    def deserialize(self, value: str) -> datetime:
+        return datetime.strptime(value, self.fmt)
+
+
+class FormattedDate(SerializationStrategy):
+    def __init__(self, fmt):
+        self.fmt = fmt
+
+    def serialize(self, value: date) -> str:
+        return value.strftime(self.fmt)
+
+    def deserialize(self, value: str) -> date:
+        return datetime.strptime(value, self.fmt).date()


### PR DESCRIPTION
## What changes do you are proposing?
In Invoice, parse `lastDate` field as Date and not as String

## How did you test these changes? 
Manually

**Closing issues**
