### PR TITLE
fix: unhashable `RemoteReading`

### DIFF
--- a/iec_api/models/remote_reading.py
+++ b/iec_api/models/remote_reading.py
@@ -68,7 +68,7 @@ class FutureConsumptionInfo(DataClassDictMixin):
     total_import_date: Optional[date] = field(metadata=field_options(alias="totalImportDate"))
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class RemoteReading(DataClassDictMixin):
     """Remote Reading Data dataclass."""
 

--- a/iec_api/models/remote_reading.py
+++ b/iec_api/models/remote_reading.py
@@ -68,13 +68,17 @@ class FutureConsumptionInfo(DataClassDictMixin):
     total_import_date: Optional[date] = field(metadata=field_options(alias="totalImportDate"))
 
 
-@dataclass(unsafe_hash=True)
+@dataclass
 class RemoteReading(DataClassDictMixin):
     """Remote Reading Data dataclass."""
 
     status: int
     date: datetime
     value: float
+
+    def __hash__(self):
+        """Compute the hash value the remote reading, based on all fields."""
+        return hash((self.status, self.date, self.value))
 
     @classmethod
     def __post_deserialize__(cls, obj: "RemoteReading") -> "RemoteReading":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iec-api"
-version = "0.2.14"
+version = "0.2.15"
 description = "A Python wrapper for Israel Electric Company API"
 authors = ["GuyKh"]
 license = "MIT"
@@ -13,7 +13,7 @@ keywords = ["python", "poetry", "api", "iec", "israel", "electric"]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-mashumaro = "^3.12"
+mashumaro = "^3.13"
 pyjwt = "^2.8.0"
 requests = "^2.31.0"
 pkce = "^1.0.3"


### PR DESCRIPTION
## **User description**
## What changes do you are proposing?
Fix unhashable using custom hash method

## How did you test these changes? 

**Closing issues**
#105


___

## **Type**
Bug fix


___

## **Description**
- The `RemoteReading` class in `iec_api/models/remote_reading.py` has been modified to include `unsafe_hash=True` in the `@dataclass` decorator. This change resolves the issue where instances of `RemoteReading` were not hashable, addressing bug #105.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remote_reading.py</strong><dd><code>Make RemoteReading Instances Hashable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
iec_api/models/remote_reading.py

<li>Added <code>unsafe_hash=True</code> to the <code>@dataclass</code> decorator for <code>RemoteReading</code> <br>to make instances hashable.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GuyKh/py-iec-api/pull/106/files#diff-9c31faefa082b72e17924203ced9c0df57f0fa6a68702d48ee8295918d05b85e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

