### PR TITLE
Fix and cleanup IEC.postman_collection.json

### DIFF
--- a/IEC.postman_collection.json
+++ b/IEC.postman_collection.json
@@ -43,13 +43,11 @@
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/json",
-								"type": "text"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
+								"value": "application/json"
 							}
 						],
 						"body": {
@@ -109,13 +107,11 @@
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/json",
-								"type": "text"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
+								"value": "application/json"
 							}
 						],
 						"body": {
@@ -178,13 +174,11 @@
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/json",
-								"type": "text"
+								"value": "application/json"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
+								"value": "application/json"
 							}
 						],
 						"body": {

--- a/IEC.postman_collection.json
+++ b/IEC.postman_collection.json
@@ -273,14 +273,7 @@
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/json",
-								"type": "text",
-								"disabled": true
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text",
+								"value": "text/html",
 								"disabled": true
 							}
 						],

--- a/IEC.postman_collection.json
+++ b/IEC.postman_collection.json
@@ -824,6 +824,106 @@
 			"response": []
 		},
 		{
+			"name": "Devices",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"// Parse the response JSON",
+							"let jsonData = JSON.parse(pm.response.text());",
+							"",
+							"// Set the variables in the environment (optional)",
+							"pm.collectionVariables.set(\"device_id\", jsonData[0].deviceNumber);",
+							"pm.collectionVariables.set(\"device_code\", jsonData[0].deviceCode);"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "authority",
+						"value": "iecapi.iec.co.il"
+					},
+					{
+						"key": "accept",
+						"value": "application/json, text/plain, */*"
+					},
+					{
+						"key": "accept-language",
+						"value": "en,he;q=0.9"
+					},
+					{
+						"key": "dnt",
+						"value": "1"
+					},
+					{
+						"key": "origin",
+						"value": "https://www.iec.co.il"
+					},
+					{
+						"key": "referer",
+						"value": "https://www.iec.co.il/"
+					},
+					{
+						"key": "sec-ch-ua",
+						"value": "\"Chromium\";v=\"121\", \"Not A(Brand\";v=\"99\""
+					},
+					{
+						"key": "sec-ch-ua-mobile",
+						"value": "?0"
+					},
+					{
+						"key": "sec-ch-ua-platform",
+						"value": "\"macOS\""
+					},
+					{
+						"key": "sec-fetch-dest",
+						"value": "empty"
+					},
+					{
+						"key": "sec-fetch-mode",
+						"value": "cors"
+					},
+					{
+						"key": "sec-fetch-site",
+						"value": "same-site"
+					},
+					{
+						"key": "user-agent",
+						"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
+					},
+					{
+						"key": "x-iec-idt",
+						"value": "1"
+					},
+					{
+						"key": "x-iec-webview",
+						"value": "1"
+					}
+				],
+				"url": {
+					"raw": "https://iecapi.iec.co.il/api/Device/{{contract_id}}",
+					"protocol": "https",
+					"host": [
+						"iecapi",
+						"iec",
+						"co",
+						"il"
+					],
+					"path": [
+						"api",
+						"Device",
+						"{{contract_id}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Get Electric Bill",
 			"request": {
 				"method": "GET",
@@ -1197,107 +1297,6 @@
 						"LastMeterReading",
 						"{{contract_id}}",
 						"{{bp_number}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Devices",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"// Parse the response JSON",
-							"let jsonData = JSON.parse(pm.response.text());",
-							"",
-							"// Set the variables in the environment (optional)",
-							"pm.collectionVariables.set(\"device_id\", jsonData[0].deviceNumber);",
-							"pm.collectionVariables.set(\"device_code\", jsonData[0].deviceCode);"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "authority",
-						"value": "iecapi.iec.co.il"
-					},
-					{
-						"key": "accept",
-						"value": "application/json, text/plain, */*"
-					},
-					{
-						"key": "accept-language",
-						"value": "en,he;q=0.9"
-					},
-					{
-						"key": "dnt",
-						"value": "1"
-					},
-					{
-						"key": "origin",
-						"value": "https://www.iec.co.il"
-					},
-					{
-						"key": "referer",
-						"value": "https://www.iec.co.il/"
-					},
-					{
-						"key": "sec-ch-ua",
-						"value": "\"Chromium\";v=\"121\", \"Not A(Brand\";v=\"99\""
-					},
-					{
-						"key": "sec-ch-ua-mobile",
-						"value": "?0"
-					},
-					{
-						"key": "sec-ch-ua-platform",
-						"value": "\"macOS\""
-					},
-					{
-						"key": "sec-fetch-dest",
-						"value": "empty"
-					},
-					{
-						"key": "sec-fetch-mode",
-						"value": "cors"
-					},
-					{
-						"key": "sec-fetch-site",
-						"value": "same-site"
-					},
-					{
-						"key": "user-agent",
-						"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
-					},
-					{
-						"key": "x-iec-idt",
-						"value": "1"
-					},
-					{
-						"key": "x-iec-webview",
-						"value": "1"
-					}
-				],
-				"url": {
-					"raw": "https://iecapi.iec.co.il//api/Device/{{contract_id}}",
-					"protocol": "https",
-					"host": [
-						"iecapi",
-						"iec",
-						"co",
-						"il"
-					],
-					"path": [
-						"",
-						"api",
-						"Device",
-						"{{contract_id}}"
 					]
 				}
 			},

--- a/IEC.postman_collection.json
+++ b/IEC.postman_collection.json
@@ -609,7 +609,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://iecapi.iec.co.il//api/outages/accounts",
+					"raw": "https://iecapi.iec.co.il/api/outages/accounts",
 					"protocol": "https",
 					"host": [
 						"iecapi",
@@ -618,7 +618,6 @@
 						"il"
 					],
 					"path": [
-						"",
 						"api",
 						"outages",
 						"accounts"
@@ -705,7 +704,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://iecapi.iec.co.il//api/customer",
+					"raw": "https://iecapi.iec.co.il/api/customer",
 					"protocol": "https",
 					"host": [
 						"iecapi",
@@ -714,7 +713,6 @@
 						"il"
 					],
 					"path": [
-						"",
 						"api",
 						"customer"
 					]
@@ -804,7 +802,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://iecapi.iec.co.il//api/customer/contract/{{bp_number}}",
+					"raw": "https://iecapi.iec.co.il/api/customer/contract/{{bp_number}}",
 					"protocol": "https",
 					"host": [
 						"iecapi",
@@ -813,7 +811,6 @@
 						"il"
 					],
 					"path": [
-						"",
 						"api",
 						"customer",
 						"contract",
@@ -990,7 +987,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://iecapi.iec.co.il//api/ElectricBillsDrawers/ElectricBills/{{contract_id}}/{{bp_number}}",
+					"raw": "https://iecapi.iec.co.il/api/ElectricBillsDrawers/ElectricBills/{{contract_id}}/{{bp_number}}",
 					"protocol": "https",
 					"host": [
 						"iecapi",
@@ -999,7 +996,6 @@
 						"il"
 					],
 					"path": [
-						"",
 						"api",
 						"ElectricBillsDrawers",
 						"ElectricBills",
@@ -1077,7 +1073,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://iecapi.iec.co.il//api/billingCollection/invoices/{{contract_id}}/{{bp_number}}",
+					"raw": "https://iecapi.iec.co.il/api/billingCollection/invoices/{{contract_id}}/{{bp_number}}",
 					"protocol": "https",
 					"host": [
 						"iecapi",
@@ -1086,7 +1082,6 @@
 						"il"
 					],
 					"path": [
-						"",
 						"api",
 						"billingCollection",
 						"invoices",
@@ -1196,7 +1191,7 @@
 					}
 				},
 				"url": {
-					"raw": "https://iecapi.iec.co.il//api/Consumption/RemoteReadingRange/{{contract_id}}",
+					"raw": "https://iecapi.iec.co.il/api/Consumption/RemoteReadingRange/{{contract_id}}",
 					"protocol": "https",
 					"host": [
 						"iecapi",
@@ -1205,7 +1200,6 @@
 						"il"
 					],
 					"path": [
-						"",
 						"api",
 						"Consumption",
 						"RemoteReadingRange",
@@ -1282,7 +1276,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://iecapi.iec.co.il//api/Device/LastMeterReading/{{contract_id}}/{{bp_number}}",
+					"raw": "https://iecapi.iec.co.il/api/Device/LastMeterReading/{{contract_id}}/{{bp_number}}",
 					"protocol": "https",
 					"host": [
 						"iecapi",
@@ -1291,7 +1285,6 @@
 						"il"
 					],
 					"path": [
-						"",
 						"api",
 						"Device",
 						"LastMeterReading",
@@ -1369,7 +1362,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://iecapi.iec.co.il//api/Device/{{contract_id}}/{{device_id}}",
+					"raw": "https://iecapi.iec.co.il/api/Device/{{contract_id}}/{{device_id}}",
 					"protocol": "https",
 					"host": [
 						"iecapi",
@@ -1378,7 +1371,6 @@
 						"il"
 					],
 					"path": [
-						"",
 						"api",
 						"Device",
 						"{{contract_id}}",
@@ -1455,7 +1447,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://iecapi.iec.co.il//api/Device/type/{{bp_number}}/{{contract_id}}/false",
+					"raw": "https://iecapi.iec.co.il/api/Device/type/{{bp_number}}/{{contract_id}}/false",
 					"protocol": "https",
 					"host": [
 						"iecapi",
@@ -1464,7 +1456,6 @@
 						"il"
 					],
 					"path": [
-						"",
 						"api",
 						"Device",
 						"type",

--- a/IEC.postman_collection.json
+++ b/IEC.postman_collection.json
@@ -391,13 +391,7 @@
 						"header": [
 							{
 								"key": "Accept",
-								"value": "application/json",
-								"type": "text"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
+								"value": "application/json"
 							}
 						],
 						"body": {

--- a/IEC.postman_collection.json
+++ b/IEC.postman_collection.json
@@ -401,13 +401,34 @@
 							}
 						],
 						"body": {
-							"mode": "raw",
-							"raw": "    {\n        \"client_id\": {{appClientId}},\n        \"code_verifier\": {{VERIFIER}},\n        \"grant_type\": \"authorization_code\",\n        \"redirect_uri\": \"com.iecrn:/\",\n        \"code\": {{oauthCode}}\n    }",
-							"options": {
-								"raw": {
-									"language": "json"
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "client_id",
+									"value": "{{appClientId}}",
+									"type": "text"
+								},
+								{
+									"key": "code_verifier",
+									"value": "{{VERIFIER}}",
+									"type": "text"
+								},
+								{
+									"key": "grant_type",
+									"value": "authorization_code",
+									"type": "text"
+								},
+								{
+									"key": "redirect_uri",
+									"value": "com.iecrn:/",
+									"type": "text"
+								},
+								{
+									"key": "code",
+									"value": "{{oauthCode}}",
+									"type": "text"
 								}
-							}
+							]
 						},
 						"url": {
 							"raw": "https://iec-ext.okta.com/oauth2/default/v1/token",


### PR DESCRIPTION
### **User description**
## What changes do you are proposing?
I have done the following fixes and cleanups.  The first one fixes a bug, the rest are mostly cleanups.  Each fix is its own commit.

1.  Remove the duplicate Content-Type header in step 5
Fix Auth step 5 remove Content-Type: application/json. Postman adds auto generates the correct Content-Type of application/x-www-form-urlencoded instead. Having the content type twice in Postman causes it to behave inconsistently, and sometimes works but not always. This change should fix it.

2. Remove type "text" from content-type parameters.  
This was done automatically by the export of the latest version of Postman.

3. Remove Content-type of application/json from step 4
Done because this step is a GET request that should not have a Content-Type header. It was disabled anyway, but I removed it as it was wrong.

4. Sort APIs list
Moved the Devices api upwards to its correct location in the list of APIs, because it must run before the RemoteReadingRange API.

5. Clean double slash in URL
Postman removes the double slash ("//") from all URLs on import. 
This empty path element makes no difference, and the API works with and without it.
This extra slash is probably a bug in the IEC front-end, and was not intended to be there by their IEC API backend developers.


## How did you test these changes? 
To test I cleared my Postman workspace. Re-imported the file, and tested that all APIs are working and returning valid data.

**Closing issues**


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Removed duplicate `Content-Type` headers in multiple steps to ensure consistent behavior in Postman.
- Removed `type: "text"` from `Content-Type` and `Accept` headers as per the latest Postman export.
- Corrected `Content-Type` for GET requests, ensuring they do not have a `Content-Type` header.
- Sorted APIs list, moving the `Devices` API upwards to its correct location.
- Cleaned double slashes in URLs, which were removed by Postman on import.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IEC.postman_collection.json</strong><dd><code>Fix headers, clean URLs, and reorder APIs in Postman collection.</code></dd></summary>
<hr>
      
IEC.postman_collection.json

<li>Removed duplicate <code>Content-Type</code> headers in multiple steps.<br> <li> Removed <code>type: "text"</code> from <code>Content-Type</code> and <code>Accept</code> headers.<br> <li> Corrected <code>Content-Type</code> for GET requests.<br> <li> Sorted APIs list and moved <code>Devices</code> API upwards.<br> <li> Cleaned double slashes in URLs.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GuyKh/py-iec-api/pull/113/files#diff-7e7d847a723b947dd48f4ba9761b47605d18bf7b85dc2af430fbfdd937614806">+117/-146</a></td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

