### PR TITLE
feat: implementation of multi-factor selection (SMS and Email)

### DIFF
--- a/iec_api/iec_client.py
+++ b/iec_api/iec_client.py
@@ -692,9 +692,7 @@ class IecClient:
 
         return await data.get_touz_compatibility(self._session, self._token, contract_id, bp_number)
 
-    async def get_mobility_status(
-        self, device_id: str, contract_id: Optional[str] = None
-    ) -> Optional[MobilityStatus]:
+    async def get_mobility_status(self, device_id: str, contract_id: Optional[str] = None) -> Optional[MobilityStatus]:
         """Get mobility status for a contract/device pair."""
         await self.check_token()
 
@@ -933,13 +931,20 @@ class IecClient:
     # Login/Token Flow
     # ----------------
 
-    async def login_with_id(self) -> Optional[str]:
+    async def login_with_id(self, prefer_sms: bool = True) -> Optional[str]:
         """
-        Login with ID and wait for OTP
+        Login with ID and wait for OTP.
+        Supports preferring SMS factor if multiple are available.
+
+        Args:
+            prefer_sms (bool): Whether to prefer SMS factor if multiple are available. Default is True.
+
         Returns:
-            str: The OTP factor type
+            str: The OTP factor type.
         """
-        state_token, factor_id, session_token, otp_factor_type = await login.first_login(self._session, self._user_id)
+        state_token, factor_id, session_token, otp_factor_type = await login.first_login(
+            self._session, self._user_id, prefer_sms=prefer_sms
+        )
         self._state_token = state_token
         self._factor_id = factor_id
         self._session_token = session_token
@@ -960,12 +965,15 @@ class IecClient:
         self.logged_in = True
         return True
 
-    async def manual_login(self):
+    async def manual_login(self, prefer_sms: bool = True):
         """
         Logs the user in by obtaining an authorization token, setting the authorization header,
         and updating the login status and token attribute.
+
+        Args:
+            prefer_sms (bool): Whether to prefer SMS factor if multiple are available. Default is True.
         """
-        token = await login.manual_authorization(self._session, self._user_id)
+        token = await login.manual_authorization(self._session, self._user_id, prefer_sms=prefer_sms)
         self.logged_in = True
         self._token = token
 

--- a/iec_api/login.py
+++ b/iec_api/login.py
@@ -70,14 +70,37 @@ async def authorize_session(session: ClientSession, session_token) -> Tuple[str,
     return code, code_verifier
 
 
-async def get_first_factor_id(session: ClientSession, user_id: str) -> Tuple[str, str]:
+def _get_factor_type(factor: dict) -> str:
+    """Get human-readable factor type."""
+    factor_type = factor.get("factorType", "")
+    email = factor.get("profile", {}).get("email", "")
+    if factor_type == "email" and "@sns.iec.co.il" in email:
+        return "sms"
+    return factor_type
+
+
+def _select_factor(factors: list[dict], prefer_sms: bool = True) -> dict:
+    """Select the preferred factor from the list."""
+    if not factors:
+        return {}
+    selected_factor = factors[0]
+    if len(factors) > 1:
+        for factor in factors:
+            is_sms = _get_factor_type(factor) == "sms"
+            if (prefer_sms and is_sms) or (not prefer_sms and not is_sms):
+                selected_factor = factor
+                break
+    return selected_factor
+
+
+async def get_auth_factors(session: ClientSession, user_id: str) -> Tuple[str, list[dict]]:
     """
-    Function to get the first factor ID using the provided ID.
-        Args:
+    Get the available factors for authentication.
+    Args:
         session: The aiohttp ClientSession object.
         user_id (str): The user ID be used for authorization.
     Returns:
-        Tuple[str,str]: [The state token, the factor id]
+        Tuple[str, list[dict]]: [The state token, the list of factors]
     """
     data = {"username": f"{user_id}@iec.co.il"}
     headers = {"accept": "application/json", "content-type": "application/json"}
@@ -85,7 +108,22 @@ async def get_first_factor_id(session: ClientSession, user_id: str) -> Tuple[str
     response = await commons.send_post_request(
         session=session, url=f"{IEC_OKTA_BASE_URL}/api/v1/authn", json_data=data, headers=headers
     )
-    return response.get("stateToken", ""), response.get("_embedded", {}).get("factors", {})[0].get("id")
+    return response.get("stateToken", ""), response.get("_embedded", {}).get("factors", [])
+
+
+async def get_first_factor_id(session: ClientSession, user_id: str, prefer_sms: bool = True) -> Tuple[str, str]:
+    """
+    Function to get the first factor ID using the provided ID.
+    Args:
+        session: The aiohttp ClientSession object.
+        user_id (str): The user ID be used for authorization.
+        prefer_sms (bool): Whether to prefer SMS if multiple factors exist.
+    Returns:
+        Tuple[str,str]: [The state token, the factor id]
+    """
+    state_token, factors = await get_auth_factors(session, user_id)
+    selected_factor = _select_factor(factors, prefer_sms)
+    return state_token, selected_factor.get("id", "")
 
 
 async def send_otp_code(
@@ -116,7 +154,8 @@ async def send_otp_code(
     )
 
     session_token = response.get("sessionToken")
-    factor_type = response.get("_embedded", {}).get("factor", {}).get("factorType")
+    factor_obj = response.get("_embedded", {}).get("factor", {})
+    factor_type = _get_factor_type(factor_obj)
 
     if response.get("status") in ("SUCCESS", "MFA_CHALLENGE"):
         return session_token, factor_type
@@ -147,13 +186,16 @@ async def get_access_token(session: ClientSession, code: str, code_verifier: str
     return JWT.from_dict(response)
 
 
-async def first_login(session: ClientSession, id_number: str) -> Tuple[str, str, Optional[str], Optional[str]]:
+async def first_login(
+    session: ClientSession, id_number: str, prefer_sms: bool = True
+) -> Tuple[str, str, Optional[str], Optional[str]]:
     """
     Perform the first login for a user.
 
     Args:
         session: The aiohttp ClientSession object.
         id_number (str): The user's ID number.
+        prefer_sms (bool): Whether to prefer SMS if multiple factors exist.
 
     Returns:
         Tuple[str, str, str, str]: A tuple containing the state token, factor ID, session token,
@@ -161,11 +203,14 @@ async def first_login(session: ClientSession, id_number: str) -> Tuple[str, str,
     """
 
     try:
-        # Get the first factor ID and state token
-        state_token, factor_id = await get_first_factor_id(session, id_number)
+        # Get the available factors and state token
+        state_token, factors = await get_auth_factors(session, id_number)
+        selected_factor = _select_factor(factors, prefer_sms)
+        factor_id = selected_factor.get("id")
+        factor_type = _get_factor_type(selected_factor)
 
         # Send OTP code and get session token
-        session_token, factor_type = await send_otp_code(session, factor_id, state_token)
+        session_token, _ = await send_otp_code(session, factor_id, state_token)
 
         return state_token, factor_id, session_token, factor_type
     except Exception as error:
@@ -198,11 +243,11 @@ async def verify_otp_code(session: ClientSession, factor_id: str, state_token: s
         raise IECLoginError(-1, "Failed at OTP verification") from error
 
 
-async def manual_authorization(session: ClientSession, id_number) -> JWT:  # pragma: no cover
+async def manual_authorization(session: ClientSession, id_number, prefer_sms: bool = True) -> JWT:  # pragma: no cover
     """Get authorization token from IEC API."""
     if not id_number:
         id_number = await commons.read_user_input("Enter your ID Number: ")
-    state_token, factor_id, session_token, factor_type = await first_login(session, id_number)
+    state_token, factor_id, session_token, factor_type = await first_login(session, id_number, prefer_sms)
     if not state_token:
         logger.error("Failed to send OTP")
         raise IECLoginError(-1, "Failed to send OTP, no state_token")

--- a/iec_api/login.py
+++ b/iec_api/login.py
@@ -81,8 +81,6 @@ def _get_factor_type(factor: dict) -> str:
 
 def _select_factor(factors: list[dict], prefer_sms: bool = True) -> dict:
     """Select the preferred factor from the list."""
-    if not factors:
-        return {}
     selected_factor = factors[0]
     if len(factors) > 1:
         for factor in factors:
@@ -123,7 +121,7 @@ async def get_first_factor_id(session: ClientSession, user_id: str, prefer_sms: 
     """
     state_token, factors = await get_auth_factors(session, user_id)
     selected_factor = _select_factor(factors, prefer_sms)
-    return state_token, selected_factor.get("id", "")
+    return state_token, selected_factor.get("id")
 
 
 async def send_otp_code(

--- a/iec_api/masa_api_models/manage_shared_accounts.py
+++ b/iec_api/masa_api_models/manage_shared_accounts.py
@@ -67,6 +67,7 @@ class SharedAccountAccount(IDWrapper):
         default=None, metadata=field_options(alias="consumptionOrderViewTypeCode")
     )
 
+
 @dataclass
 class SharedAccountConnectionType(IDWrapper):
     logical_name: str = field(metadata=field_options(alias="logicalName"))

--- a/tests/auth_factor_test.py
+++ b/tests/auth_factor_test.py
@@ -48,7 +48,7 @@ class AuthFactorTest(unittest.IsolatedAsyncioTestCase):
     @patch("iec_api.commons.send_post_request")
     async def test_get_first_factor_id_no_factors(self, mock_post):
         mock_post.return_value = {"stateToken": "token123", "_embedded": {"factors": []}}
-        
+
         with self.assertRaises(IndexError):
             await login.get_first_factor_id(AsyncMock(), "123456782", prefer_sms=True)
 

--- a/tests/auth_factor_test.py
+++ b/tests/auth_factor_test.py
@@ -1,0 +1,72 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from iec_api import login
+
+
+class AuthFactorTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.factors_response = {
+            "stateToken": "token123",
+            "_embedded": {
+                "factors": [
+                    {"id": "f1", "factorType": "email", "profile": {"email": "user@sns.iec.co.il"}},
+                    {"id": "f2", "factorType": "email", "profile": {"email": "user@gmail.com"}},
+                ]
+            },
+        }
+
+    @patch("iec_api.commons.send_post_request")
+    async def test_get_first_factor_id_prefer_sms(self, mock_post):
+        mock_post.return_value = self.factors_response
+
+        # Should pick f1 because it's sms
+        state_token, factor_id = await login.get_first_factor_id(AsyncMock(), "123456782", prefer_sms=True)
+        self.assertEqual(factor_id, "f1")
+        self.assertEqual(state_token, "token123")
+
+    @patch("iec_api.commons.send_post_request")
+    async def test_get_first_factor_id_prefer_email(self, mock_post):
+        mock_post.return_value = self.factors_response
+
+        # Should pick f2 because it's NOT sms
+        state_token, factor_id = await login.get_first_factor_id(AsyncMock(), "123456782", prefer_sms=False)
+        self.assertEqual(factor_id, "f2")
+
+    @patch("iec_api.commons.send_post_request")
+    async def test_get_first_factor_id_single_factor(self, mock_post):
+        single_factor = {
+            "stateToken": "token123",
+            "_embedded": {"factors": [{"id": "f2", "factorType": "email", "profile": {"email": "user@gmail.com"}}]},
+        }
+        mock_post.return_value = single_factor
+
+        # Should pick f2 even if sms preferred because it's the only one
+        state_token, factor_id = await login.get_first_factor_id(AsyncMock(), "123456782", prefer_sms=True)
+        self.assertEqual(factor_id, "f2")
+
+    def test_get_factor_type_sms(self):
+        factor = {"factorType": "email", "profile": {"email": "test@sns.iec.co.il"}}
+        self.assertEqual(login._get_factor_type(factor), "sms")
+
+    def test_get_factor_type_email(self):
+        factor = {"factorType": "email", "profile": {"email": "test@gmail.com"}}
+        self.assertEqual(login._get_factor_type(factor), "email")
+
+    def test_select_factor_logic(self):
+        factors = [
+            {"id": "sms", "factorType": "email", "profile": {"email": "a@sns.iec.co.il"}},
+            {"id": "email", "factorType": "email", "profile": {"email": "b@gmail.com"}},
+        ]
+
+        self.assertEqual(login._select_factor(factors, prefer_sms=True)["id"], "sms")
+        self.assertEqual(login._select_factor(factors, prefer_sms=False)["id"], "email")
+
+        # Reverse order
+        factors_rev = [factors[1], factors[0]]
+        self.assertEqual(login._select_factor(factors_rev, prefer_sms=True)["id"], "sms")
+        self.assertEqual(login._select_factor(factors_rev, prefer_sms=False)["id"], "email")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/auth_factor_test.py
+++ b/tests/auth_factor_test.py
@@ -45,6 +45,13 @@ class AuthFactorTest(unittest.IsolatedAsyncioTestCase):
         state_token, factor_id = await login.get_first_factor_id(AsyncMock(), "123456782", prefer_sms=True)
         self.assertEqual(factor_id, "f2")
 
+    @patch("iec_api.commons.send_post_request")
+    async def test_get_first_factor_id_no_factors(self, mock_post):
+        mock_post.return_value = {"stateToken": "token123", "_embedded": {"factors": []}}
+        
+        with self.assertRaises(IndexError):
+            await login.get_first_factor_id(AsyncMock(), "123456782", prefer_sms=True)
+
     def test_get_factor_type_sms(self):
         factor = {"factorType": "email", "profile": {"email": "test@sns.iec.co.il"}}
         self.assertEqual(login._get_factor_type(factor), "sms")


### PR DESCRIPTION
### feat: implementation of multi-factor selection (SMS and Email)

This PR introduces support for multiple authentication factors during the login process. Currently, the library defaults to the first factor returned by the OKTA API, which can lead to confusion when a user has both SMS and Email factors registered.

#### Key Changes
- **Multi-Factor Selection**: Added logic to choose between different factors based on a new `prefer_sms` parameter (defaulting to `True` to maintain backward compatibility for existing users).
- **SMS Gateway Detection**: Implemented detection for the `@sns.iec.co.il` domain, which the IEC uses for SMS-to-Email gateway factors, allowing them to be correctly identified as `sms` rather than `email`.
- **API Updates**:
    - `IecClient.login_with_id(prefer_sms=True)` now accepts a preference.
    - Updated `login.py` with helper functions `_get_factor_type` and `_select_factor` for cleaner factor resolution.
- **Improved UX**: The factor type returned now accurately reflects "sms" or "email" for informative messages, even if the underlying OKTA API reports both as email types.

#### Verification Results
- Added `tests/auth_factor_test.py` verifying:
    - `@sns` domain is correctly mapped to `sms`.
    - Preference logic correctly picks the right factor when multiple exist.
    - Single-factor users default to their only factor.
- Verified that existing tests (`tests/commons_test.py`, `tests/remote_reading_test.py`) still pass.
