### PR TITLE
fix: make verification_status optional in MasaMainPortalContactAccountUserProfile

### DIFF
--- a/iec_api/masa_api_models/contact_account_user_profile.py
+++ b/iec_api/masa_api_models/contact_account_user_profile.py
@@ -310,9 +310,5 @@ class MasaMainPortalContactAccountUserProfile(DataClassDictMixin):
     )
     id: UUID = field(metadata=field_options(alias="id"))
     logical_name: str = field(metadata=field_options(alias="logicalName"))
-    # Optional: the profile endpoint omits "verificationStatus" for some accounts
-    # (e.g. accounts on a private supplier), so a required bool breaks parsing.
-    # Moved below the remaining required fields to keep dataclass field ordering
-    # valid once it has a default.
     verification_status: Optional[bool] = field(default=None, metadata=field_options(alias="verificationStatus"))
     last_name: Optional[str] = field(default=None, metadata=field_options(alias="lastName"))

--- a/iec_api/masa_api_models/contact_account_user_profile.py
+++ b/iec_api/masa_api_models/contact_account_user_profile.py
@@ -308,7 +308,11 @@ class MasaMainPortalContactAccountUserProfile(DataClassDictMixin):
     connection_between_contact_and_contract: List[ConnectionBetweenContactAndContract] = field(
         metadata=field_options(alias="connectionBetweenContactAndContract")
     )
-    verification_status: bool = field(metadata=field_options(alias="verificationStatus"))
     id: UUID = field(metadata=field_options(alias="id"))
     logical_name: str = field(metadata=field_options(alias="logicalName"))
+    # Optional: the profile endpoint omits "verificationStatus" for some accounts
+    # (e.g. accounts on a private supplier), so a required bool breaks parsing.
+    # Moved below the remaining required fields to keep dataclass field ordering
+    # valid once it has a default.
+    verification_status: Optional[bool] = field(default=None, metadata=field_options(alias="verificationStatus"))
     last_name: Optional[str] = field(default=None, metadata=field_options(alias="lastName"))

--- a/tests/contact_account_user_profile_test.py
+++ b/tests/contact_account_user_profile_test.py
@@ -1,0 +1,64 @@
+import unittest
+
+from iec_api.masa_api_models.contact_account_user_profile import (
+    MasaMainPortalContactAccountUserProfile,
+)
+
+
+def _base_payload() -> dict:
+    """A minimal valid MASA main-portal user-profile payload (no verificationStatus)."""
+    return {
+        "governmentid": "000000000",
+        "idType": 1,
+        "firstName": "Test",
+        "email": "test@example.com",
+        "phoneNumber": "0500000000",
+        "accounts": [],
+        "phonePrefix": "050",
+        "isConnectedToPrivateAccount": True,
+        "isAccountOwner": True,
+        "isAccountContact": False,
+        "connectionBetweenContactAndContract": [],
+        "id": "4cbc8831-1c73-e811-8102-3863bb357f98",
+        "logicalName": "contact",
+    }
+
+
+class MasaMainPortalContactAccountUserProfileTest(unittest.TestCase):
+    def test_parse_without_verification_status(self):
+        """The endpoint omits verificationStatus for some accounts (e.g. private
+        supplier); parsing must succeed and default the field to None."""
+        payload = _base_payload()
+        self.assertNotIn("verificationStatus", payload)
+
+        profile = MasaMainPortalContactAccountUserProfile.from_dict(payload)
+
+        self.assertIsNone(profile.verification_status)
+
+    def test_parse_with_verification_status(self):
+        """When verificationStatus is present it is preserved (both True and False)."""
+        for value in (True, False):
+            with self.subTest(value=value):
+                payload = _base_payload()
+                payload["verificationStatus"] = value
+
+                profile = MasaMainPortalContactAccountUserProfile.from_dict(payload)
+
+                self.assertEqual(profile.verification_status, value)
+
+    def test_serialization_preserves_verification_status(self):
+        """Serialization keeps the value. The model deserializes by the
+        verificationStatus alias but to_dict emits the field name (it has no
+        serialize_by_alias config), so assert the value is retained."""
+        payload = _base_payload()
+        payload["verificationStatus"] = True
+
+        profile = MasaMainPortalContactAccountUserProfile.from_dict(payload)
+        serialized = profile.to_dict()
+
+        self.assertIn("verification_status", serialized)
+        self.assertTrue(serialized["verification_status"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #283

## Problem

The main-portal user-profile endpoint omits `verificationStatus` for some accounts (observed on an account tied to a private supplier). Because `verification_status` was a required `bool`, mashumaro deserialization fails:

```
Field "verification_status" of type bool is missing in MasaMainPortalContactAccountUserProfile instance
```

which surfaces in iec-custom-component as a "No active contracts found" / reauth loop even though login succeeds and the account has active smart-meter contracts.

## Fix

Make `verification_status` `Optional[bool] = None`, consistent with prior fixes to this same model (#239, #240, #249).

It is **moved below** the remaining required fields (`id`, `logical_name`); adding a default in place would raise `non-default argument follows default argument`. Field order does not affect mashumaro deserialization (it maps by `alias`).

## Verification

Ran the actual model against a real profile payload:

- **Without** `verificationStatus` → now parses, `verification_status is None` (previously raised).
- **With** `verificationStatus` → still parses (`True`), backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)